### PR TITLE
ARI-Client Impose URL as basePath

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -220,7 +220,7 @@ SwaggerApi.prototype.buildFrom1_1Spec = function(response) {
     }
   }
   if (response.basePath) {
-    this.basePath = response.basePath;
+    this.basePath = this.url.replace('/api-docs/resources.json','');
   } else if (this.url.indexOf('?') > 0) {
     this.basePath = this.url.substring(0, this.url.lastIndexOf('?'));
   } else {


### PR DESCRIPTION
Modifying Swagger_Client as a dependency of ARI-Client to use passed url as basepath for asterisk api resources rather than asterisk response url.